### PR TITLE
Bump Microsoft.Extensions.Caching.Memory to 2.1.2

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Microsoft.Teams.Apps.FAQPlusPlus.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Search" Version="10.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Ai.QnA" Version="4.5.2" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.0" />
     <PackageReference Include="Microsoft.MarkedNet" Version="1.0.13" />


### PR DESCRIPTION
- Upgraded nuget package Microsoft.Extensions.Caching.Memory from 2.1.1 to 2.1.2 in FaqPlusPlus project [https://www.nuget.org/packages/Microsoft.Extensions.Caching.Memory/2.1.2]