### PR TITLE
Ignore errors from sending the typing indicator

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Bots/FaqPlusPlusBot.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
         private readonly string appBaseUri;
         private readonly IKnowledgeBaseSearchService knowledgeBaseSearchService;
         private readonly ILogger<FaqPlusPlusBot> logger;
-        private IQnaServiceProvider qnaServiceProvider;
+        private readonly IQnaServiceProvider qnaServiceProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FaqPlusPlusBot"/> class.
@@ -1067,11 +1067,19 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Bots
         /// </summary>
         /// <param name="turnContext">Context object containing information cached for a single turn of conversation with a user.</param>
         /// <returns>A task that represents the work queued to execute.</returns>
-        private Task SendTypingIndicatorAsync(ITurnContext turnContext)
+        private async Task SendTypingIndicatorAsync(ITurnContext turnContext)
         {
-            var typingActivity = turnContext.Activity.CreateReply();
-            typingActivity.Type = ActivityTypes.Typing;
-            return turnContext.SendActivityAsync(typingActivity);
+            try
+            {
+                var typingActivity = turnContext.Activity.CreateReply();
+                typingActivity.Type = ActivityTypes.Typing;
+                await turnContext.SendActivityAsync(typingActivity);
+            }
+            catch (Exception ex)
+            {
+                // Do not fail on errors sending the typing indicator
+                this.logger.LogWarning(ex, "Failed to send a typing indicator");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Bots posting typing-indicators to users in Europe region are receiving 502s at this time, as typing indicator support is scaled down temporarily to provide more resources to other scenarios.

This change suppresses the exception thrown by sending the typing indicator, so that a failure to post the indicator is not a fatal error. The exception is still logged to App Insights so that the admin can monitor the ultimate resolution of this issue.